### PR TITLE
Fix: build error on api object

### DIFF
--- a/dashboard/composables/useFetchData.ts
+++ b/dashboard/composables/useFetchData.ts
@@ -1,8 +1,6 @@
 import { Ref } from 'vue'
 const { getSession } = useAuth()
 
-const session = await getSession()
-
 export const useFetchData = async (
   path: string,
   page?: Ref<number>,
@@ -166,6 +164,7 @@ export const usePostServicePhoto = async (body: object) => {
 
 export const usePostData = async (path: string, body: object) => {
   const config = useRuntimeConfig()
+  const session = await getSession()
   return new Promise(async (resolve, reject) => {
     try {
       await useFetch(config.public.baseURL.concat(`${path}`), {


### PR DESCRIPTION
## Changes 
- Fixing error build on netlify causing by top level await

# Evidence
title: Build Error on Api Object
project: Jabar Super Apps
participants: @rayfajars @johndy2742 @ristianaditya @MNAlfiansyah 